### PR TITLE
docs(security): add SECURITY.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the Python Community Code of Conduct.
+
+See https://www.python.org/psf/conduct/ for the full text. By participating, you agree to uphold this code.
+
+If you observe or experience unacceptable behavior, please contact security@qrius.global.
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+Please do not open public issues for security vulnerabilities.
+
+Report suspected vulnerabilities privately to security@qrius.global with details and a minimal reproduction if possible.
+
+We will acknowledge receipt within 72 hours and work with you on remediation and coordinated disclosure.
+


### PR DESCRIPTION
Adds security policy and code of conduct. Follows trunk-based via PR.\n\n- SECURITY.md with contact\n- CODE_OF_CONDUCT.md referencing Python Community CoC